### PR TITLE
fix: wrong exit code output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/pyupio/safety:3.0.0-615ef36
+FROM ghcr.io/pyupio/safety:3.2.3-a6de00f
 
 COPY entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -80,8 +80,8 @@ output="${output//$'\n'/'%0A'}"  # Replace newline characters with %0A
 output="${output//$'\r'/'%0D'}"  # Replace carriage return characters with %0D
 
 # Output the exit code and CLI output for GitHub Actions to consume
-echo "{exit-code}={$exit_code}" >> $GITHUB_OUTPUT
-echo "{cli-output}={$output}" >> $GITHUB_OUTPUT
+echo "exit-code=$exit_code" >> $GITHUB_OUTPUT
+echo "cli-output=$output" >> $GITHUB_OUTPUT
 
 # Exit with the same code as the Safety CLI command
 exit $exit_code

--- a/multi-ecosystem/entrypoint.sh
+++ b/multi-ecosystem/entrypoint.sh
@@ -80,8 +80,8 @@ output="${output//$'\n'/'%0A'}"  # Replace newline characters with %0A
 output="${output//$'\r'/'%0D'}"  # Replace carriage return characters with %0D
 
 # Output the exit code and CLI output for GitHub Actions to consume
-echo "{exit-code}={$exit_code}" >> $GITHUB_OUTPUT
-echo "{cli-output}={$output}" >> $GITHUB_OUTPUT
+echo "exit-code=$exit_code" >> $GITHUB_OUTPUT
+echo "cli-output=$output" >> $GITHUB_OUTPUT
 
 # Exit with the same code as the Safety CLI command
 exit $exit_code


### PR DESCRIPTION
This PR updates the action to use Safety CLI version 3.2.3, including enhanced exit code handling for unknown severities.
