### PR TITLE
feat: support safety-version input in the GitHub action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
   debug:
     required: false
     default: false
+  safety-version:
+    required: false
+    default: ''
 
 outputs:
   cli-output:
@@ -37,6 +40,7 @@ runs:
     GITHUB_TOKEN: ${{ inputs.repo-token }}
     SAFETY_ACTION_VERSION: 1.0.0
     SAFETY_ACTION: true
+    SAFETY_VERSION: ${{ inputs.safety-version }}
     COLUMNS: 120
     FORCE_COLOR: 1
     NON_INTERACTIVE: 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,22 @@ if [[ "${SAFETY_API_KEY:-}" == "" ]]; then
     exit 1
 fi
 
+# Install Safety CLI if a version is specified
+# This is not cool but it's the only way to do it without making too many changes
+if [ -z "$SAFETY_VERSION" ]; then
+    echo "Using Safety CLI version from base image"
+elif [ "$SAFETY_VERSION" = "latest" ]; then
+    echo "Installing latest Safety CLI version (including pre-releases if available)"
+    python3 -m pip install --upgrade --pre safety > /dev/null 2>&1
+elif [ "$SAFETY_VERSION" = "stable" ]; then
+    echo "Installing latest Safety CLI stable version"
+    python3 -m pip install --upgrade safety > /dev/null 2>&1
+else
+    echo "Installing Safety CLI version $SAFETY_VERSION"
+    python3 -m pip install safety==$SAFETY_VERSION > /dev/null 2>&1
+fi
+
+export SAFETY_SOURCE_TYPE="urn:safetycli:cli:github:action"
 export SAFETY_OS_TYPE="docker action"
 export SAFETY_OS_RELEASE=""
 export SAFETY_OS_DESCRIPTION=""


### PR DESCRIPTION
Add support for `safety-version`; installing it is not ideal, but this was the most straightforward method.