### PR TITLE
fix: use explicit version specifier instead of --pre flag for safety installation

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ if [ -z "$SAFETY_VERSION" ]; then
     echo "Using Safety CLI version from base image"
 elif [ "$SAFETY_VERSION" = "latest" ]; then
     echo "Installing latest Safety CLI version (including pre-releases if available)"
-    python3 -m pip install --upgrade --pre safety > /dev/null 2>&1
+    python3 -m pip install --upgrade "safety>=3.0.0dev0" > /dev/null 2>&1
 elif [ "$SAFETY_VERSION" = "stable" ]; then
     echo "Installing latest Safety CLI stable version"
     python3 -m pip install --upgrade safety > /dev/null 2>&1


### PR DESCRIPTION
The `--pre` flag was causing pip to install development versions of dependencies like httpx 1.0dev0, which contains breaking changes that break safety functionality. By switching to an explicit version specifier '>=3.0.0dev0', we maintain access to safety pre-releases while avoiding unintended installation of unstable dependency versions.