### PR TITLE
Information about default policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Safety can be integrated into your existing GitHub CI pipeline as an action. Jus
 
 (Don't have an API Key? You can sign up for one with [https://safetycli.com/resources/plans](https://safetycli.com/resources/plans).)
 
-This will run Safety scan and It'll fail your CI pipeline if any vulnerable packages are found.
+This will run Safety scan and it'll fail your CI pipeline if vulnerable packages are found depending on your policy settings.
+
+Without modifications to the above workflow, the policy settings are automatically loaded from the organization linked to with the `SAFETY_API_KEY`. By default, only vulnerabilities with severity levels `critical`, `high` or `medium` will fail the CI pipeline. You can easily modify the policy via the [Dashboard](https://platform.safetycli.com/organization/policies).
 
 If you have something more complicated such as a monorepo; or once you're finished testing, read the [Documentation](https://docs.safetycli.com/) for more details on configuring Safety as an action.


### PR DESCRIPTION
Currently, the description on when Safety will fail the CI pipeline is misleading. It states that it will fail on *any* vulnerability found. But this is untrue. The default policy, which every user using the provided workflow snippet and creating a new account with safetycli.com will have, will only fail on `critical`, `high` or `medium` vulnerabilities.

I added this information to the README.md and how to change the default policy easily via the dashboard.

Related to https://github.com/pyupio/safety-action/issues/10